### PR TITLE
Use proxy-id instead of target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ CMD_DIR := ./cmd
 OUTPUT_DIR := .
 OUTPUT_PATH := $(OUTPUT_DIR)/$(BINARY_NAME)
 
-.PHONY: all build clean
+.PHONY: all build clean test test-verbose test-coverage test-race test-short test-clean benchmark test-auth test-crypto test-proxy test-utils
 
 all: build
 
@@ -12,3 +12,38 @@ build:
 
 clean:
 	rm -f $(OUTPUT_PATH)
+
+# Test targets
+test:
+	go test ./...
+
+test-verbose:
+	go test -v ./...
+
+test-coverage:
+	go test -cover ./...
+
+test-race:
+	go test -race ./...
+
+test-short:
+	go test -short ./...
+
+test-clean:
+	go clean -testcache
+
+benchmark:
+	go test -bench=. ./...
+
+# Package-specific test targets
+test-auth:
+	go test ./auth/...
+
+test-crypto:
+	go test ./crypto/...
+
+test-proxy:
+	go test ./proxy/...
+
+test-utils:
+	go test ./utils/...

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -20,6 +20,7 @@ import (
 var configFilePath string
 
 // TODO: graceful shutdown
+// TODO: refactor
 func main() {
 	app := &cli.App{
 		Name:  "tclp",
@@ -67,7 +68,6 @@ func main() {
 			}
 
 			fmt.Printf("listening on %s:%d\n", cfg.Server.Host, cfg.Server.Port)
-
 			err = grpcServer.Serve(lis)
 
 			return err
@@ -119,7 +119,7 @@ func configureProxy(proxyConns *proxy.Conn, cfg *utils.Config) error {
 		}
 
 		err := proxyConns.AddConn(proxy.AddConnInput{
-			Source:          t.Source,
+			ProxyId:         t.ProxyId,
 			Target:          t.Target,
 			TLSCertPath:     t.TLS.CertFile,
 			TLSKeyPath:      t.TLS.KeyFile,

--- a/config.yaml
+++ b/config.yaml
@@ -3,7 +3,7 @@ server:
   host: "0.0.0.0"
 
 targets:
-  - source: "<namespace>.<account>.internal"
+  - proxy_id: "<namespace>.<account>"
     target: "<namespace>.<account>.tmprl.cloud:7233"
     tls:
       cert_file: "/path/to/<namespace>.<account>/tls.crt"

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 )
 
 require (
+	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/go-jose/go-jose/v4 v4.0.4 // indirect
 	github.com/zeebo/errs v1.4.0 // indirect
 	golang.org/x/crypto v0.37.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ cloud.google.com/go/kms v1.22.0/go.mod h1:U7mf8Sva5jpOb4bxYZdtw/9zsbIjrklYwPcvMk
 cloud.google.com/go/longrunning v0.6.7 h1:IGtfDWHhQCgCjwQjV9iiLnUta9LBCo8R9QmAFsS/PrE=
 cloud.google.com/go/longrunning v0.6.7/go.mod h1:EAFV3IZAKmM56TyiE6VAP3VoTzhZzySwI/YI1s/nRsY=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
+github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/aws/aws-sdk-go v1.55.7 h1:UJrkFq7es5CShfBwlWAC8DA077vp8PyVbQd3lqLiztE=
 github.com/aws/aws-sdk-go v1.55.7/go.mod h1:eRwEWoyTWFMVYVQzKMNHWP5/RV4xIUGMQfXQHfHkpNU=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=

--- a/utils/config.go
+++ b/utils/config.go
@@ -11,7 +11,7 @@ type ServerConfig struct {
 }
 
 type TargetConfig struct {
-	Source         string      `yaml:"source"`
+	ProxyId        string      `yaml:"proxy_id"`
 	Target         string      `yaml:"target"`
 	TLS            TLSConfig   `yaml:"tls"`
 	EncryptionKey  string      `yaml:"encryption_key"`

--- a/utils/config_manager_test.go
+++ b/utils/config_manager_test.go
@@ -24,7 +24,7 @@ server:
   port: 7233
   host: "0.0.0.0"
 targets:
-  - source: "test.internal"
+  - proxy_id: "test.internal"
     target: "test.external:7233"
     tls:
       cert_file: "/path/to/cert.crt"
@@ -55,7 +55,7 @@ server:
   port: 7233
   host: "0.0.0.0"
 targets:
-  - source: "test.internal"
+  - proxy_id: "test.internal"
     target: "test.external:7233"
     invalid: yaml: [
 `,
@@ -135,14 +135,14 @@ server:
   port: 9090
   host: "127.0.0.1"
 targets:
-  - source: "test1.internal"
+  - proxy_id: "test1.internal"
     target: "test1.external:9090"
     tls:
       cert_file: "/test1.crt"
       key_file: "/test1.key"
     encryption_key: "key1"
     namespace: "namespace1"
-  - source: "test2.internal"
+  - proxy_id: "test2.internal"
     target: "test2.external:9091"
     tls:
       cert_file: "/test2.crt"
@@ -189,8 +189,8 @@ targets:
 
 	if len(config.Targets) >= 1 {
 		target1 := config.Targets[0]
-		if target1.Source != "test1.internal" {
-			t.Errorf("Expected first target source to be 'test1.internal', got %s", target1.Source)
+		if target1.ProxyId != "test1.internal" {
+			t.Errorf("Expected first target proxy_id to be 'test1.internal', got %s", target1.ProxyId)
 		}
 		if target1.Authentication != nil {
 			t.Error("Expected first target to have no authentication")
@@ -199,8 +199,8 @@ targets:
 
 	if len(config.Targets) >= 2 {
 		target2 := config.Targets[1]
-		if target2.Source != "test2.internal" {
-			t.Errorf("Expected second target source to be 'test2.internal', got %s", target2.Source)
+		if target2.ProxyId != "test2.internal" {
+			t.Errorf("Expected second target proxy_id to be 'test2.internal', got %s", target2.ProxyId)
 		}
 		if target2.Authentication == nil {
 			t.Error("Expected second target to have authentication")
@@ -216,7 +216,7 @@ server:
   port: 8080
   host: "localhost"
 targets:
-  - source: "concurrent.internal"
+  - proxy_id: "concurrent.internal"
     target: "concurrent.external:8080"
     tls:
       cert_file: "/concurrent.crt"
@@ -263,7 +263,7 @@ targets:
 					errors <- err
 					return
 				}
-				if config.Targets[0].Source != "concurrent.internal" {
+				if config.Targets[0].ProxyId != "concurrent.internal" {
 					errors <- err
 					return
 				}
@@ -329,7 +329,7 @@ server:
   port: 7233
   host: "0.0.0.0"
 targets:
-  - source: "test.internal"
+  - proxy_id: "test.internal"
     target: "test.external:7233"
     tls:
       cert_file: "/path/to/cert.crt"
@@ -358,7 +358,7 @@ server:
   port: 7233
   host: "0.0.0.0"
 targets:
-  - source: "test.internal"
+  - proxy_id: "test.internal"
     target: "test.external:7233"
     invalid: [unclosed
 `,
@@ -506,7 +506,7 @@ server:
   port: 7233
   host: "0.0.0.0"
 targets:
-  - source: "bench.internal"
+  - proxy_id: "bench.internal"
     target: "bench.external:7233"
     tls:
       cert_file: "/bench.crt"
@@ -545,7 +545,7 @@ server:
   port: 7233
   host: "0.0.0.0"
 targets:
-  - source: "bench.internal"
+  - proxy_id: "bench.internal"
     target: "bench.external:7233"
     tls:
       cert_file: "/bench.crt"

--- a/utils/config_test.go
+++ b/utils/config_test.go
@@ -20,7 +20,7 @@ server:
   port: 7233
   host: "0.0.0.0"
 targets:
-  - source: "test.namespace.internal"
+  - proxy_id: "test.namespace.internal"
     target: "test.namespace.tmprl.cloud:7233"
     tls:
       cert_file: "/path/to/cert.crt"
@@ -42,7 +42,7 @@ targets:
 				},
 				Targets: []TargetConfig{
 					{
-						Source:        "test.namespace.internal",
+						ProxyId:       "test.namespace.internal",
 						Target:        "test.namespace.tmprl.cloud:7233",
 						EncryptionKey: "test-key",
 						Namespace:     "test.namespace",
@@ -70,7 +70,7 @@ server:
   port: 8080
   host: "localhost"
 targets:
-  - source: "simple.internal"
+  - proxy_id: "simple.internal"
     target: "simple.external:8080"
     tls:
       cert_file: "/cert.crt"
@@ -85,7 +85,7 @@ targets:
 				},
 				Targets: []TargetConfig{
 					{
-						Source:        "simple.internal",
+						ProxyId:       "simple.internal",
 						Target:        "simple.external:8080",
 						EncryptionKey: "simple-key",
 						Namespace:     "simple",
@@ -106,14 +106,14 @@ server:
   port: 9090
   host: "127.0.0.1"
 targets:
-  - source: "target1.internal"
+  - proxy_id: "target1.internal"
     target: "target1.external:9090"
     tls:
       cert_file: "/target1.crt"
       key_file: "/target1.key"
     encryption_key: "key1"
     namespace: "namespace1"
-  - source: "target2.internal"
+  - proxy_id: "target2.internal"
     target: "target2.external:9091"
     tls:
       cert_file: "/target2.crt"
@@ -133,7 +133,7 @@ targets:
 				},
 				Targets: []TargetConfig{
 					{
-						Source:        "target1.internal",
+						ProxyId:       "target1.internal",
 						Target:        "target1.external:9090",
 						EncryptionKey: "key1",
 						Namespace:     "namespace1",
@@ -144,7 +144,7 @@ targets:
 						Authentication: nil,
 					},
 					{
-						Source:        "target2.internal",
+						ProxyId:       "target2.internal",
 						Target:        "target2.external:9091",
 						EncryptionKey: "key2",
 						Namespace:     "namespace2",
@@ -244,7 +244,7 @@ func TestServerConfig_Validation(t *testing.T) {
 
 func TestTargetConfig_Structure(t *testing.T) {
 	target := TargetConfig{
-		Source:        "test.internal",
+		ProxyId:       "test.internal",
 		Target:        "test.external:7233",
 		EncryptionKey: "test-key",
 		Namespace:     "test-namespace",
@@ -260,8 +260,8 @@ func TestTargetConfig_Structure(t *testing.T) {
 		},
 	}
 
-	if target.Source != "test.internal" {
-		t.Errorf("Expected Source to be 'test.internal', got %s", target.Source)
+	if target.ProxyId != "test.internal" {
+		t.Errorf("Expected ProxyId to be 'test.internal', got %s", target.ProxyId)
 	}
 	if target.Target != "test.external:7233" {
 		t.Errorf("Expected Target to be 'test.external:7233', got %s", target.Target)
@@ -363,7 +363,7 @@ func configEqual(a, b Config) bool {
 }
 
 func targetConfigEqual(a, b TargetConfig) bool {
-	if a.Source != b.Source || a.Target != b.Target || a.EncryptionKey != b.EncryptionKey || a.Namespace != b.Namespace {
+	if a.ProxyId != b.ProxyId || a.Target != b.Target || a.EncryptionKey != b.EncryptionKey || a.Namespace != b.Namespace {
 		return false
 	}
 


### PR DESCRIPTION
Use a proxy-id header set by the Temporal worker to identify which target connection to Temporal Cloud the proxy should use. Previously this was done by looking at the host/authority header.